### PR TITLE
Expand thinks_with enum with 8 new values

### DIFF
--- a/airth_npcs.schema.json
+++ b/airth_npcs.schema.json
@@ -48,7 +48,22 @@
         "oddly_also": { "type": ["string", "null"] },
         "thinks_with": {
           "type": "string",
-          "enum": ["fists", "magic", "persuasion", "money", "blade", "lore"]
+          "enum": [
+            "blade",
+            "devotion",
+            "endurance",
+            "faith",
+            "fear",
+            "fists",
+            "guilt",
+            "honor",
+            "lore",
+            "magic",
+            "money",
+            "persuasion",
+            "pride",
+            "tradition"
+          ]
         },
         "family": { "type": "string" },
         "self_image": { "type": ["string", "null"] },


### PR DESCRIPTION
## Summary
- Adds 8 new values to the `thinks_with` controlled vocabulary: `devotion`, `endurance`, `faith`, `fear`, `guilt`, `honor`, `pride`, `tradition`
- Mapped to upcoming NPCs: Zimru (faith), Maedra (devotion), Velric (guilt), Ulan (honor), Tenn Darnel (pride), Mollgarn (endurance), Ulzhar (fear), elders (tradition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)