### PR TITLE
Make home_settlement a reference field

### DIFF
--- a/airth_npcs.schema.json
+++ b/airth_npcs.schema.json
@@ -38,7 +38,10 @@
       "properties": {
         "moniker": { "type": ["string", "null"] },
         "home": { "type": "string" },
-        "home_settlement": { "type": "string" },
+        "home_settlement": {
+          "type": "string",
+          "$comment": "Reference: must match a key in airth_settlements.json. Use 'itinerant' for NPCs with no fixed settlement."
+        },
         "gender": { "type": "string" },
         "faction": {
           "type": "string",


### PR DESCRIPTION
## Summary
- Changes `home_settlement` from a plain string to a documented reference field pointing to keys in `airth_settlements.json`
- Adding a new settlement to `airth_settlements.json` now makes it immediately valid on any NPC — no schema update needed
- Special value `itinerant` retained for NPCs like Taziri with no fixed settlement

🤖 Generated with [Claude Code](https://claude.com/claude-code)