### PR TITLE
Add NPC validation test suite

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,34 @@
+"""
+Shared fixtures for the Airth campaign test suite.
+Loads JSON data files once and makes them available to all tests.
+"""
+
+import json
+import pytest
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+
+
+@pytest.fixture(scope="session")
+def npcs():
+    with open(ROOT / "airth_npcs.json") as f:
+        return json.load(f)["npcs"]
+
+
+@pytest.fixture(scope="session")
+def schema():
+    with open(ROOT / "airth_npcs.schema.json") as f:
+        return json.load(f)
+
+
+@pytest.fixture(scope="session")
+def settlements():
+    with open(ROOT / "airth_settlements.json") as f:
+        return json.load(f)["settlements"]
+
+
+@pytest.fixture(scope="session")
+def npc_schema(schema):
+    """The NPC definition block from the schema."""
+    return schema["definitions"]["npc"]

--- a/tests/test_npcs.py
+++ b/tests/test_npcs.py
@@ -1,0 +1,97 @@
+"""
+NPC validation tests for the Airth campaign.
+
+Each test checks one rule. Failures report exactly which NPC and field
+caused the problem.
+"""
+
+ITINERANT = "itinerant"  # special value for NPCs with no fixed settlement
+
+
+# ---------------------------------------------------------------------------
+# Required fields
+# ---------------------------------------------------------------------------
+
+REQUIRED_FIELDS = [
+    "moniker", "home", "home_settlement", "gender", "faction",
+    "appearance", "and_yet", "wants", "does_not_want", "oddly_also",
+    "thinks_with", "family", "self_image", "recreation", "dreams",
+    "anecdotes", "tragedies", "pc_leverage",
+]
+
+def test_required_fields_present(npcs):
+    """Every NPC must have all required fields."""
+    missing = []
+    for npc_key, npc in npcs.items():
+        for field in REQUIRED_FIELDS:
+            if field not in npc:
+                missing.append(f"{npc_key}: missing '{field}'")
+    assert not missing, "Missing required fields:\n" + "\n".join(missing)
+
+
+# ---------------------------------------------------------------------------
+# Enum: thinks_with
+# ---------------------------------------------------------------------------
+
+def test_thinks_with_is_valid_enum(npcs, npc_schema):
+    """thinks_with must be a value in the blessed enum list."""
+    valid = set(npc_schema["properties"]["thinks_with"]["enum"])
+    invalid = []
+    for npc_key, npc in npcs.items():
+        value = npc.get("thinks_with")
+        if value and value not in valid:
+            invalid.append(f"{npc_key}: '{value}' not in thinks_with enum")
+    assert not invalid, "\n".join(invalid)
+
+
+# ---------------------------------------------------------------------------
+# Enum: faction
+# ---------------------------------------------------------------------------
+
+def test_faction_is_valid_enum(npcs, npc_schema):
+    """faction must be a value in the blessed enum list."""
+    valid = set(npc_schema["properties"]["faction"]["enum"])
+    invalid = []
+    for npc_key, npc in npcs.items():
+        value = npc.get("faction")
+        if value and value not in valid:
+            invalid.append(f"{npc_key}: '{value}' not in faction enum")
+    assert not invalid, "\n".join(invalid)
+
+
+# ---------------------------------------------------------------------------
+# Reference: home_settlement
+# ---------------------------------------------------------------------------
+
+def test_home_settlement_references_exist(npcs, settlements):
+    """home_settlement must be a key in airth_settlements.json, or 'itinerant'."""
+    invalid = []
+    for npc_key, npc in npcs.items():
+        value = npc.get("home_settlement")
+        if value and value != ITINERANT and value not in settlements:
+            invalid.append(f"{npc_key}: '{value}' not found in airth_settlements.json")
+    assert not invalid, "\n".join(invalid)
+
+
+# ---------------------------------------------------------------------------
+# Arrays
+# ---------------------------------------------------------------------------
+
+def test_anecdotes_are_strings(npcs):
+    """All entries in anecdotes must be strings."""
+    invalid = []
+    for npc_key, npc in npcs.items():
+        for i, item in enumerate(npc.get("anecdotes", [])):
+            if not isinstance(item, str):
+                invalid.append(f"{npc_key}: anecdotes[{i}] is not a string")
+    assert not invalid, "\n".join(invalid)
+
+
+def test_tragedies_are_strings(npcs):
+    """All entries in tragedies must be strings."""
+    invalid = []
+    for npc_key, npc in npcs.items():
+        for i, item in enumerate(npc.get("tragedies", [])):
+            if not isinstance(item, str):
+                invalid.append(f"{npc_key}: tragedies[{i}] is not a string")
+    assert not invalid, "\n".join(invalid)


### PR DESCRIPTION
## Summary
- Adds `tests/conftest.py` — shared fixtures that load JSON files once per session
- Adds `tests/test_npcs.py` — six validation tests:
  - Required fields present on every NPC
  - `thinks_with` matches blessed enum
  - `faction` matches blessed enum
  - `home_settlement` references a real key in `airth_settlements.json` (or `itinerant`)
  - `anecdotes` and `tragedies` contain only strings
- Currently 5 pass, 1 known failure: `mother_yaleth` references `nemetra` which doesn't exist in `airth_settlements.json` yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)